### PR TITLE
Add proper `type` and refactored `cli` and `transform` functionalities

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,18 +43,8 @@ pub fn parse_arguments_and_read_file(args: &Arguments) -> Result<(String, Option
     Ok((source_code, err_file))
 }
 
-pub fn update_source_code(args: &Arguments, new_code: String) -> Result<()> {
-    fs::remove_file(&args.source_file)
-        .with_context(|| format!("could not remove file `{}`", &args.source_file.display()))?;
-
-    fs::write(&args.source_file, new_code).with_context(|| {
-        format!(
-            "could not write updated code to file `{}`",
-            &args.source_file.display()
-        )
-    })?;
-
-    Ok(())
+pub fn print_source_code(source_code: &String) {
+    println!("{source_code}");
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod cli;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 use std::fs;
 
@@ -14,12 +14,8 @@ fn main() -> Result<()> {
 fn try_parse() -> Result<()> {
     let args = cli::Arguments::parse();
 
-    if !args.source_file.exists() {
-        // TODO: return a proper error type about how the file wasn't found/doesn't exist
-        panic!("File {:?} not found", args.source_file);
-    }
-
-    let code = fs::read_to_string(&args.source_file)?;
+    let code = fs::read_to_string(&args.source_file)
+        .with_context(|| format!("could not read file `{}`", args.source_file.display()))?;
 
     let new_code = transform_code(&code, RUSTTEST_ERROR);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod transform;
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -17,43 +18,15 @@ fn try_parse() -> Result<()> {
     let code = fs::read_to_string(&args.source_file)
         .with_context(|| format!("could not read file `{}`", args.source_file.display()))?;
 
-    let new_code = transform_code(&code, RUSTTEST_ERROR);
+    let new_code = transform::transform_code(&code).with_context(|| {
+        format!(
+            "could not transform code from file `{}`",
+            args.source_file.display()
+        )
+    })?;
 
     fs::remove_file(&args.source_file)?;
     fs::write(&args.source_file, new_code.join("\n"))?;
 
     Ok(())
-}
-
-/// This function takes the rust code and rust directive
-/// and returns the code with dejagnu directive
-fn transform_code(code: &str, rust_directive: &str) -> Vec<String> {
-    let mut new_code = Vec::new();
-
-    for line in code.lines() {
-        if line.contains(rust_directive) {
-            // replace the rust directive to dejagnu directive
-            // TODO: Add more directive relative to rustc
-            let new_line = line.replace(rust_directive, DG_ERROR);
-
-            // format the line according to dejagnu format
-            let new_line = format!("{}\" }}", new_line);
-            new_code.push(new_line);
-        } else {
-            new_code.push(line.to_string());
-        }
-    }
-    new_code
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_transform_code() {
-        let dg_msg = "// { dg-error \"expected one of `:`, `@`, or `|`, found `)`\" }";
-        let rust_msg = "//~^ ERROR expected one of `:`, `@`, or `|`, found `)`";
-        assert_eq!(transform_code(rust_msg, RUSTTEST_ERROR), vec![dg_msg]);
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,8 @@
-mod cli;
-mod transform;
-
 use anyhow::{Context, Result};
 use clap::Parser;
-use std::fs;
 
-const RUSTTEST_ERROR: &str = "//~^ ERROR ";
-const DG_ERROR: &str = "// { dg-error \"";
+mod cli;
+mod transform;
 
 fn main() -> Result<()> {
     try_parse()
@@ -15,8 +11,7 @@ fn main() -> Result<()> {
 fn try_parse() -> Result<()> {
     let args = cli::Arguments::parse();
 
-    let code = fs::read_to_string(&args.source_file)
-        .with_context(|| format!("could not read file `{}`", args.source_file.display()))?;
+    let (code, _stderr_code) = cli::parse_arguments_and_read_file(&args)?;
 
     let new_code = transform::transform_code(&code).with_context(|| {
         format!(
@@ -25,8 +20,7 @@ fn try_parse() -> Result<()> {
         )
     })?;
 
-    fs::remove_file(&args.source_file)?;
-    fs::write(&args.source_file, new_code.join("\n"))?;
+    cli::update_source_code(&args, new_code)?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn try_parse() -> Result<()> {
         )
     })?;
 
-    cli::update_source_code(&args, new_code)?;
+    cli::print_source_code(&new_code);
 
     Ok(())
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,0 +1,48 @@
+use anyhow::Result;
+
+// TODO: Add more directive relative to rustc and DejaGnu
+pub const RUSTTEST_ERROR: &'static str = "//~^ ERROR ";
+pub const DG_ERROR: &'static str = "// { dg-error \"";
+
+/// This function takes the rust code and rust directive
+/// and returns the code with DejaGnu directive
+pub fn transform_code(code: &str) -> Result<String> {
+    let new_code = code
+        .lines()
+        .map(|line| {
+            if line.contains(RUSTTEST_ERROR) {
+                transform_line(line, RUSTTEST_ERROR, DG_ERROR)
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Ok(new_code)
+}
+
+fn transform_line(line: &str, rust_directive: &str, dejagnu_directive: &str) -> String {
+    let new_line = line.replace(rust_directive, dejagnu_directive);
+    // format the line according to DejaGnu format
+    format!("{}\" }}", new_line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_transform() {
+        let dg_msg = "// { dg-error \"expected one of `:`, `@`, or `|`, found `)`\" }";
+        let rust_msg = "//~^ ERROR expected one of `:`, `@`, or `|`, found `)`";
+        assert_eq!(transform_code(rust_msg).unwrap(), dg_msg);
+    }
+
+    #[test]
+    fn test_transform_line() {
+        let dg_msg = "// { dg-error \"expected one of `:`, `@`, or `|`, found `)`\" }";
+        let rust_msg = "//~^ ERROR expected one of `:`, `@`, or `|`, found `)`";
+        assert_eq!(transform_line(rust_msg, RUSTTEST_ERROR, DG_ERROR), dg_msg);
+    }
+}

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 
 // TODO: Add more directive relative to rustc and DejaGnu
-pub const RUSTTEST_ERROR: &'static str = "//~^ ERROR ";
-pub const DG_ERROR: &'static str = "// { dg-error \"";
+pub const RUSTTEST_ERROR: &str = "//~^ ERROR ";
+pub const DG_ERROR: &str = "// { dg-error \"";
 
 /// This function takes the rust code and rust directive
 /// and returns the code with DejaGnu directive


### PR DESCRIPTION
- Fixes https://github.com/Rust-GCC/rusttest-to-dg/issues/2 by using [`anyhow with_context`](https://docs.rs/anyhow/latest/anyhow/trait.Context.html#tymethod.with_context) method
- Updated the return type from `Vec<String>` to `String` 
- Refactored into each function, for parsing, converting source code to `String` variables, for removing and creating a file with updated code