### PR TITLE
Add logic for parsing all `rustc` directives and converting to `dejagnu` directive with relative line numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+    "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,11 +149,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+dependencies = [
+    "aho-corasick",
+    "memchr",
+    "regex-automata",
+    "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+    "aho-corasick",
+    "memchr",
+    "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
 name = "rusttest-to-dg"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+    "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.8", features = ["derive"] }
+regex = "1.10.5"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,7 +43,7 @@ pub fn parse_arguments_and_read_file(args: &Arguments) -> Result<(String, Option
     Ok((source_code, err_file))
 }
 
-pub fn print_source_code(source_code: &String) {
+pub fn print_source_code(source_code: &str) {
     println!("{source_code}");
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -66,30 +66,34 @@ pub struct Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use RustcErrorKind::*;
+
         let error_code = self.error_code.as_ref().map_or("", |code| &code[..]);
+
+        let error_type = match &self.kind {
+            Some(Help) => "help",
+            Some(Error) => "dg-error",
+            Some(Note) => "dg-note",
+            Some(Suggestion) => "suggestion",
+            Some(Warning) => "dg-warning",
+            None => "dg-error",
+        };
+
+        let error_code = if error_code.is_empty() {
+            error_code.to_owned()
+        } else {
+            format!(".{}.", error_code)
+        };
+
+        let rel_line_number = if self.relative_line_num == 0 {
+            "".to_owned()
+        } else {
+            format!(".{} ", self.relative_line_num)
+        };
+
         write!(
             f,
-            "// {{ {} \"{}\" \"\" {{ target *-*-* }} {}}}",
-            match &self.kind {
-                Some(kind) => match kind {
-                    RustcErrorKind::Help => "help",
-                    RustcErrorKind::Error => "dg-error",
-                    RustcErrorKind::Note => "dg-note",
-                    RustcErrorKind::Suggestion => "suggestion",
-                    RustcErrorKind::Warning => "dg-warning",
-                },
-                None => "dg-error",
-            },
-            if !error_code.is_empty() {
-                format!(".{}.", error_code)
-            } else {
-                error_code.to_owned()
-            },
-            if self.relative_line_num == 0 {
-                "".to_owned()
-            } else {
-                format!(".{} ", self.relative_line_num)
-            },
+            "// {{ {error_type} \"{error_code}\" \"\" {{ target *-*-* }} {rel_line_number}}}"
         )
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -91,32 +91,6 @@ impl fmt::Display for Error {
                 format!(".{} ", self.relative_line_num)
             },
         )
-        // let error_code = self.error_code.as_ref().map_or("", |code| &code[..]);
-        // write!(
-        //     f,
-        //     "// {{ {} \"{}{}\" \"\" {{ target *-*-* }} {}}}",
-        //     match &self.kind {
-        //         Some(kind) => match kind {
-        //             RustcErrorKind::Help => "help",
-        //             RustcErrorKind::Error => "dg-error",
-        //             RustcErrorKind::Note => "dg-note",
-        //             RustcErrorKind::Suggestion => "suggestion",
-        //             RustcErrorKind::Warning => "dg-warning",
-        //         },
-        //         None => "dg-error",
-        //     },
-        //     self.msg,
-        //     if !error_code.is_empty() {
-        //         format!(" .{}.", error_code)
-        //     } else {
-        //         error_code.to_owned()
-        //     },
-        //     if self.relative_line_num == 0 {
-        //         "".to_owned()
-        //     } else {
-        //         format!(".{} ", self.relative_line_num)
-        //     },
-        // )
     }
 }
 
@@ -173,7 +147,6 @@ fn is_error_code(s: &str) -> bool {
 }
 
 fn parse_error_code(stderr_content: &str) -> Vec<StderrResult> {
-    // TODO: This will check for only one error code in the stderr file, add support for multiple error codes
     // Modified regex pattern with named capture groups
     let re: OnceCell<Regex> = OnceCell::new();
     let error_pattern = re.get_or_init(|| {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,3 @@
-use std::{fmt, str::FromStr};
 
 // https://rustc-dev-guide.rust-lang.org/tests/ui.html#error-levels
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -42,6 +41,114 @@ impl fmt::Display for RustcErrorKind {
             RustcErrorKind::Warning => write!(f, "warning"),
         }
     }
+}
+
+#[derive(Debug)]
+pub struct Error {
+    pub line_num: usize,
+    /// We also need to take into account the relative line number.
+    /// if the error is on the previous line, then it's value is `1`.
+    /// if the error is on the same line, then it's value is `0`.
+    /// if the error is on the next line, then it's value is `-1`.
+    pub relative_line_num: i32,
+
+    /// What kind of message we expect (e.g., warning, error, suggestion).
+    /// `None` if not specified or unknown message kind.
+    pub kind: Option<RustcErrorKind>,
+    pub msg: String,
+    pub error_code: Option<String>,
+#[derive(PartialEq, Debug)]
+enum WhichLine {
+    ThisLine,
+    FollowPrevious(usize),
+    AdjustBackward(usize),
+}
+
+pub fn load_error(text_file: &str) -> Vec<Error> {
+    let mut last_unfollow_error = None;
+    let mut errors = Vec::new();
+
+    for (line_num, line) in text_file.lines().enumerate() {
+        if let Some((which, error)) = parse_expected(last_unfollow_error, line_num + 1, line) {
+            match which {
+                FollowPrevious(_) => {}
+                _ => last_unfollow_error = Some(line_num),
+            }
+            errors.push(error);
+        }
+    }
+
+    errors
+}
+
+fn parse_expected(
+    last_nonfollow_error: Option<usize>,
+    line_num: usize,
+    line: &str,
+) -> Option<(WhichLine, Error)> {
+    // Matches comments like:
+    //     //~
+    //     //~|
+    //     //~^
+    //     //~^^^^^
+    static RE: OnceLock<Regex> = OnceLock::new();
+
+    let captures = RE
+        .get_or_init(|| Regex::new(r"//(?:\[(?P<revs>[\w\-,]+)])?~(?P<adjust>\||\^*)").unwrap())
+        .captures(line)?;
+
+    let (follow, adjusts) = match &captures["adjust"] {
+        "|" => (true, 0),
+        circumflexes => (false, circumflexes.len()),
+    };
+
+    // Get the part of the comment after the sigil (e.g. `~^^` or ~|).
+    let whole_match = captures.get(0).unwrap();
+    let (_, mut msg) = line.split_at(whole_match.end());
+
+    let first_word = msg
+        .split_whitespace()
+        .next()
+        .expect("Encountered unexpected empty comment");
+
+    // If we find `//~ ERROR foo` or something like that, skip the first word.
+    let kind = first_word.parse::<RustcErrorKind>().ok();
+    if kind.is_some() {
+        msg = msg.trim_start().split_at(first_word.len()).1;
+    }
+
+    let msg = msg.trim().to_owned();
+
+    let mut relative_line_num = line_num as i32;
+    let (which, line_num) = if follow {
+        assert_eq!(adjusts, 0, "use either //~| or //~^, not both.");
+        let line_num = last_nonfollow_error.expect(
+            "encountered //~| without \
+             preceding //~^ line.",
+        );
+        relative_line_num = (line_num as i32) - relative_line_num;
+        (FollowPrevious(line_num), line_num)
+    } else {
+        let which = if adjusts > 0 {
+            AdjustBackward(adjusts)
+        } else {
+            ThisLine
+        };
+        let line_num = line_num - adjusts;
+        relative_line_num = -(adjusts as i32);
+        (which, line_num)
+    };
+
+    Some((
+        which,
+        Error {
+            line_num,
+            kind,
+            msg,
+            error_code: "E0000".to_owned().into(),
+            relative_line_num,
+        },
+    ))
 }
 
 #[cfg(test)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -183,7 +183,7 @@ fn parse_expected(
             line_num,
             kind,
             msg,
-            error_code: "E0000".to_owned().into(),
+            error_code: None,
             relative_line_num,
         },
     ))

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -69,7 +69,7 @@ impl fmt::Display for Error {
         let error_code = self.error_code.as_ref().map_or("", |code| &code[..]);
         write!(
             f,
-            "// {{ {} \"{}{}\" \"\" {{ target *-*-* }} {}}}",
+            "// {{ {} \"{}\" \"\" {{ target *-*-* }} {}}}",
             match &self.kind {
                 Some(kind) => match kind {
                     RustcErrorKind::Help => "help",
@@ -80,9 +80,8 @@ impl fmt::Display for Error {
                 },
                 None => "dg-error",
             },
-            self.msg,
             if !error_code.is_empty() {
-                format!(" .{}.", error_code)
+                format!(".{}.", error_code)
             } else {
                 error_code.to_owned()
             },
@@ -92,6 +91,32 @@ impl fmt::Display for Error {
                 format!(".{} ", self.relative_line_num)
             },
         )
+        // let error_code = self.error_code.as_ref().map_or("", |code| &code[..]);
+        // write!(
+        //     f,
+        //     "// {{ {} \"{}{}\" \"\" {{ target *-*-* }} {}}}",
+        //     match &self.kind {
+        //         Some(kind) => match kind {
+        //             RustcErrorKind::Help => "help",
+        //             RustcErrorKind::Error => "dg-error",
+        //             RustcErrorKind::Note => "dg-note",
+        //             RustcErrorKind::Suggestion => "suggestion",
+        //             RustcErrorKind::Warning => "dg-warning",
+        //         },
+        //         None => "dg-error",
+        //     },
+        //     self.msg,
+        //     if !error_code.is_empty() {
+        //         format!(" .{}.", error_code)
+        //     } else {
+        //         error_code.to_owned()
+        //     },
+        //     if self.relative_line_num == 0 {
+        //         "".to_owned()
+        //     } else {
+        //         format!(".{} ", self.relative_line_num)
+        //     },
+        // )
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -69,7 +69,7 @@ impl fmt::Display for Error {
         let error_code = self.error_code.as_ref().map_or("", |code| &code[..]);
         write!(
             f,
-            "// {{ {} \"{} {}\" \"\" {{ target *-*-* }} {}}}",
+            "// {{ {} \"{}{}\" \"\" {{ target *-*-* }} {}}}",
             match &self.kind {
                 Some(kind) => match kind {
                     RustcErrorKind::Help => "help",
@@ -82,7 +82,7 @@ impl fmt::Display for Error {
             },
             self.msg,
             if !error_code.is_empty() {
-                format!(".{}.", error_code)
+                format!(" .{}.", error_code)
             } else {
                 error_code.to_owned()
             },

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -67,10 +67,9 @@ pub struct Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let error_code = self.error_code.as_ref().map_or("", |code| &code[..]);
-        let relative_line_num = format!(".{}", self.relative_line_num);
         write!(
             f,
-            "// {{ {} \"{} {}\" \"\" {{ target *-*-* }} {} }}",
+            "// {{ {} \"{} {}\" \"\" {{ target *-*-* }} {}}}",
             match &self.kind {
                 Some(kind) => match kind {
                     RustcErrorKind::Help => "help",
@@ -87,7 +86,11 @@ impl fmt::Display for Error {
             } else {
                 error_code.to_owned()
             },
-            relative_line_num
+            if self.relative_line_num == 0 {
+                "".to_owned()
+            } else {
+                format!(".{} ", self.relative_line_num)
+            },
         )
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -123,7 +123,7 @@ pub fn load_error(text_file: &str, stderr_file: Option<&str>) -> Vec<Error> {
         return errors;
     }
     // TODO: improve this code incrementally
-    let error_code_stderr = parse_error_code(stderr_file.unwrap());
+    let error_code_stderr = parse_error_code(stderr_file.expect("stderr file is not found"));
 
     for error in errors.iter_mut() {
         for error_code in error_code_stderr.iter() {
@@ -178,7 +178,9 @@ fn parse_error_code(stderr_content: &str) -> Vec<StderrResult> {
         results.push(StderrResult {
             error_code,
             error_message_detail,
-            line_number: line_number.parse::<usize>().unwrap(),
+            line_number: line_number
+                .parse::<usize>()
+                .expect("expected line number to be a valid number"),
         });
     }
 
@@ -207,7 +209,9 @@ fn parse_expected(
     };
 
     // Get the part of the comment after the sigil (e.g. `~^^` or ~|).
-    let whole_match = captures.get(0).unwrap();
+    let whole_match = captures
+        .get(0)
+        .expect("Failed to parse comments like \"//~\" \"//~^\" \"//~^^^^^\" ");
     let (_, mut msg) = line.split_at(whole_match.end());
 
     let first_word = msg

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -52,9 +52,9 @@ impl fmt::Display for RustcErrorKind {
 pub struct Error {
     pub line_num: usize,
     /// We also need to take into account the relative line number.
-    /// if the error is on the previous line, then it's value is `1`.
-    /// if the error is on the same line, then it's value is `0`.
-    /// if the error is on the next line, then it's value is `-1`.
+    /// - `1` if the error is on the previous line
+    /// - `0` if the error is on the same line
+    /// - `-1` if the error is on the next line
     pub relative_line_num: i32,
 
     /// What kind of message we expect (e.g., warning, error, suggestion).

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,138 @@
+use std::{fmt, str::FromStr};
+
+// https://rustc-dev-guide.rust-lang.org/tests/ui.html#error-levels
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum RustcErrorKind {
+    Help,
+    Error,
+    Note,
+    Suggestion,
+    Warning,
+}
+
+impl FromStr for RustcErrorKind {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.to_uppercase();
+        // Some RustcErrorKinds has this colon, so we need to split it
+        // See this for example:
+        // https://github.com/rust-lang/rust/blob/master/tests/ui/async-await/in-trait/fn-not-async-err.rs#L9
+        let part0: &str = s
+            .split(':')
+            .next()
+            .expect("split always returns at least one element");
+        match part0 {
+            "HELP" => Ok(RustcErrorKind::Help),
+            "ERROR" => Ok(RustcErrorKind::Error),
+            "NOTE" => Ok(RustcErrorKind::Note),
+            "SUGGESTION" => Ok(RustcErrorKind::Suggestion),
+            "WARN" | "WARNING" => Ok(RustcErrorKind::Warning),
+            _ => Err(()),
+        }
+    }
+}
+
+impl fmt::Display for RustcErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            RustcErrorKind::Help => write!(f, "help message"),
+            RustcErrorKind::Error => write!(f, "error"),
+            RustcErrorKind::Note => write!(f, "note"),
+            RustcErrorKind::Suggestion => write!(f, "suggestion"),
+            RustcErrorKind::Warning => write!(f, "warning"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str_help_returns_help() {
+        assert_eq!(
+            RustcErrorKind::from_str("help").unwrap(),
+            RustcErrorKind::Help
+        );
+        assert_eq!(
+            RustcErrorKind::from_str("help:").unwrap(),
+            RustcErrorKind::Help
+        );
+    }
+
+    #[test]
+    fn from_str_error_returns_error() {
+        assert_eq!(
+            RustcErrorKind::from_str("error").unwrap(),
+            RustcErrorKind::Error
+        );
+    }
+
+    #[test]
+    fn from_str_note_returns_note() {
+        assert_eq!(
+            RustcErrorKind::from_str("note").unwrap(),
+            RustcErrorKind::Note
+        );
+    }
+
+    #[test]
+    fn from_str_suggestion_returns_suggestion() {
+        assert_eq!(
+            RustcErrorKind::from_str("suggestion").unwrap(),
+            RustcErrorKind::Suggestion
+        );
+    }
+
+    #[test]
+    fn from_str_warning_returns_warning() {
+        assert_eq!(
+            RustcErrorKind::from_str("warning").unwrap(),
+            RustcErrorKind::Warning
+        );
+    }
+
+    #[test]
+    fn from_str_warn_returns_warning() {
+        assert_eq!(
+            RustcErrorKind::from_str("warn").unwrap(),
+            RustcErrorKind::Warning
+        );
+    }
+
+    #[test]
+    fn from_str_unrecognized_returns_err() {
+        assert!(RustcErrorKind::from_str("unrecognized").is_err());
+    }
+
+    #[test]
+    fn from_str_empty_string_returns_err() {
+        // split always returns at least one element
+        assert!(RustcErrorKind::from_str("").is_err());
+    }
+
+    #[test]
+    fn display_help_outputs_correct_string() {
+        assert_eq!(format!("{}", RustcErrorKind::Help), "help message");
+    }
+
+    #[test]
+    fn display_error_outputs_correct_string() {
+        assert_eq!(format!("{}", RustcErrorKind::Error), "error");
+    }
+
+    #[test]
+    fn display_note_outputs_correct_string() {
+        assert_eq!(format!("{}", RustcErrorKind::Note), "note");
+    }
+
+    #[test]
+    fn display_suggestion_outputs_correct_string() {
+        assert_eq!(format!("{}", RustcErrorKind::Suggestion), "suggestion");
+    }
+
+    #[test]
+    fn display_warning_outputs_correct_string() {
+        assert_eq!(format!("{}", RustcErrorKind::Warning), "warning");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 
 mod cli;
+mod errors;
 mod transform;
 
 fn main() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,9 @@ fn main() -> Result<()> {
 fn try_parse() -> Result<()> {
     let args = cli::Arguments::parse();
 
-    let (code, _stderr_code) = cli::parse_arguments_and_read_file(&args)?;
+    let (code, stderr_code) = cli::parse_arguments_and_read_file(&args)?;
 
-    let new_code = transform::transform_code(&code).with_context(|| {
+    let new_code = transform::transform_code(&code, stderr_code.as_deref()).with_context(|| {
         format!(
             "could not transform code from file `{}`",
             args.source_file.display()

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,4 +1,4 @@
-use std::sync::OnceLock;
+use std::cell::OnceCell;
 
 use anyhow::Result;
 use regex::Regex;
@@ -26,9 +26,9 @@ pub fn transform_code(code: &str, stderr_file: Option<&str>) -> Result<String> {
                 new_line = format!("{}", error);
             } else {
                 // For the error on the same line
-                static RE: OnceLock<Regex> = OnceLock::new();
+                let re: OnceCell<Regex> = OnceCell::new();
 
-                let captures = RE
+                let captures = re
                     .get_or_init(|| {
                         Regex::new(r"//(?:\[(?P<revs>[\w\-,]+)])?~(?P<adjust>\||\^*)").unwrap()
                     })

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -56,7 +56,8 @@ mod tests {
 
     #[test]
     fn test_transform() {
-        let dg_msg = "// { dg-error \"expected one of `:`, `@`, or `|`, found `)`\" \"\" { target *-*-* } .-1 }\n";
+        // as suggested by @CohenArthur, we only need to add error code in msg
+        let dg_msg = "// { dg-error \"\" \"\" { target *-*-* } .-1 }\n";
         let rust_msg = "//~^ ERROR expected one of `:`, `@`, or `|`, found `)`";
         assert_eq!(transform_code(rust_msg, None).unwrap(), dg_msg);
     }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,4 +1,7 @@
+use crate::errors;
 use anyhow::Result;
+use regex::Regex;
+use std::sync::OnceLock;
 
 // TODO: Add more directive relative to rustc and DejaGnu
 pub const RUSTTEST_ERROR: &str = "//~^ ERROR ";
@@ -7,17 +10,44 @@ pub const DG_ERROR: &str = "// { dg-error \"";
 /// This function takes the rust code and rust directive
 /// and returns the code with DejaGnu directive
 pub fn transform_code(code: &str) -> Result<String> {
-    let new_code = code
-        .lines()
-        .map(|line| {
-            if line.contains(RUSTTEST_ERROR) {
-                transform_line(line, RUSTTEST_ERROR, DG_ERROR)
-            } else {
-                line.to_string()
+    let errors = errors::load_error(code);
+    let mut new_code = String::new();
+
+    let mut line_num = 1;
+    for line in code.lines() {
+        let mut new_line = line.to_string();
+        // TODO: This is not the efficient way to find respective line number
+        for error in errors.iter() {
+            if (error.line_num as i32 - error.relative_line_num) != line_num {
+                continue;
             }
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+            // In rustc test suites, the error directive is
+            // on the same line or the next line not on the previous line
+            // For the error on the next line
+            if error.relative_line_num != 0 {
+                new_line = format!("\t{}", error);
+            } else {
+                // For the error on the same line
+                static RE: OnceLock<Regex> = OnceLock::new();
+
+                let captures = RE
+                    .get_or_init(|| {
+                        Regex::new(r"//(?:\[(?P<revs>[\w\-,]+)])?~(?P<adjust>\||\^*)").unwrap()
+                    })
+                    .captures(line)
+                    .expect("Could not find the error directive");
+
+                // Get the part of comment before the sigil (e.g. `~^` or ~|)
+                let whole_match = captures.get(0).unwrap();
+                let before_match = &line[..whole_match.start()];
+                new_line = format!("{}{}", before_match, error);
+            }
+            break;
+        }
+        new_code.push_str(&new_line);
+        new_code.push_str("\n");
+        line_num += 1;
+    }
 
     Ok(new_code)
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,12 +1,14 @@
-use crate::errors;
+use std::sync::OnceLock;
+
 use anyhow::Result;
 use regex::Regex;
-use std::sync::OnceLock;
+
+use crate::errors;
 
 /// This function takes the rust code as input
 /// and returns the code with DejaGnu directive
-pub fn transform_code(code: &str) -> Result<String> {
-    let errors = errors::load_error(code);
+pub fn transform_code(code: &str, stderr_file: Option<&str>) -> Result<String> {
+    let errors = errors::load_error(code, stderr_file);
     let mut new_code = String::new();
 
     let mut line_num = 1;
@@ -56,6 +58,6 @@ mod tests {
     fn test_transform() {
         let dg_msg = "// { dg-error \"expected one of `:`, `@`, or `|`, found `)`\" \"\" { target *-*-* } .-1 }\n";
         let rust_msg = "//~^ ERROR expected one of `:`, `@`, or `|`, found `)`";
-        assert_eq!(transform_code(rust_msg).unwrap(), dg_msg);
+        assert_eq!(transform_code(rust_msg, None).unwrap(), dg_msg);
     }
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -54,7 +54,7 @@ mod tests {
 
     #[test]
     fn test_transform() {
-        let dg_msg = "// { dg-error \"expected one of `:`, `@`, or `|`, found `)` \" \"\" { target *-*-* } .-1 }\n";
+        let dg_msg = "// { dg-error \"expected one of `:`, `@`, or `|`, found `)`\" \"\" { target *-*-* } .-1 }\n";
         let rust_msg = "//~^ ERROR expected one of `:`, `@`, or `|`, found `)`";
         assert_eq!(transform_code(rust_msg).unwrap(), dg_msg);
     }


### PR DESCRIPTION

- Add `RustcErrorKind` enum and `FromStr/Display` impl along with test for each feature
- Add Regex as dependency
- Add logic to `load_errors` into Error struct
- Add default formatter for Error Struct, this help's in formatting according to dejagnu format
- Use `load_error` logic in transform_code function


---

- Depends on: https://github.com/Rust-GCC/rusttest-to-dg/pull/5