### PR TITLE
Use global static `Regex` variable for pattern matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
-    "memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -131,6 +131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,10 +160,10 @@ version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
-    "aho-corasick",
-    "memchr",
-    "regex-automata",
-    "regex-syntax",
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -166,9 +172,9 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
-    "aho-corasick",
-    "memchr",
-    "regex-syntax",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -183,7 +189,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
-    "regex",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.8", features = ["derive"] }
+once_cell = "1.19.0"
 regex = "1.10.5"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,15 +1,19 @@
+//! This module contains the command line interface for the tool
+
 use {
     anyhow::{Context, Result},
     clap::Parser,
     std::{fs, path},
 };
 
+/// Command line arguments for the tool
 #[derive(Parser, Debug)]
 #[command(
     name = "rust test to DejaGnu",
     long_about = "A tool to convert rust tests into DejaGnu tests format"
 )]
 pub struct Arguments {
+    /// The rust source file to convert into `DejaGnu` format
     #[arg(
         short = 'f',
         long = "file",
@@ -18,6 +22,7 @@ pub struct Arguments {
     )]
     pub source_file: path::PathBuf,
 
+    /// optional `stderr` file
     #[arg(
         short = 'e',
         long = "stderr",
@@ -33,6 +38,7 @@ pub fn parse_arguments_and_read_file(args: &Arguments) -> Result<(String, Option
     let source_code = fs::read_to_string(&args.source_file)
         .with_context(|| format!("could not read sourcefile `{}`", args.source_file.display()))?;
 
+    // Read the stderr file if it exists
     let err_file =
         match &args.stderr_file {
             Some(stderr_file) => Some(fs::read_to_string(stderr_file).with_context(|| {
@@ -66,6 +72,8 @@ mod tests {
         assert_eq!(args.stderr_file, Some(path::PathBuf::from("test.stderr")));
     }
 
+    /// clap reports most development errors as `debug_assert!`s
+    /// See this for more details, [here](https://docs.rs/clap/4.5.15/clap/_derive/_tutorial/chapter_4/index.html)
     #[test]
     fn debug_args() {
         use clap::CommandFactory;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,8 @@
-use std::{fs, path};
-
-use anyhow::{Context, Result};
-use clap::Parser;
+use {
+    anyhow::{Context, Result},
+    clap::Parser,
+    std::{fs, path},
+};
 
 #[derive(Parser, Debug)]
 #[command(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -135,7 +135,7 @@ pub fn load_error(text_file: &str, stderr_file: Option<&str>) -> Vec<Error> {
     for error in errors.iter_mut() {
         for error_code in error_code_stderr.iter() {
             if error.line_num == error_code.line_number
-                && error.msg == error_code.error_message_detail
+                || error.msg == error_code.error_message_detail
             {
                 error.error_code = Some(error_code.error_code.clone());
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,14 @@ use regex::Regex;
 
 use self::WhichLine::*;
 
+// https://docs.rs/once_cell/1.19.0/once_cell/#lazily-compiled-regex
+#[macro_export]
+macro_rules! regex {
+    ($re:literal $(,)?) => {{
+        static RE: once_cell::sync::OnceCell<regex::Regex> = once_cell::sync::OnceCell::new();
+        RE.get_or_init(|| regex::Regex::new($re).unwrap())
+    }};
+}
 // https://rustc-dev-guide.rust-lang.org/tests/ui.html#error-levels
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum RustcErrorKind {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,7 @@
-use std::{cell::OnceCell, fmt, str::FromStr};
-
-use regex::Regex;
-
-use self::WhichLine::*;
+use {
+    self::WhichLine::*,
+    std::{fmt, str::FromStr},
+};
 
 // https://docs.rs/once_cell/1.19.0/once_cell/#lazily-compiled-regex
 #[macro_export]
@@ -153,17 +152,14 @@ struct StderrResult {
 }
 
 fn is_error_code(s: &str) -> bool {
-    let re: OnceCell<Regex> = OnceCell::new();
-    let regex = re.get_or_init(|| Regex::new(r"^E\d{4}$").unwrap());
-    regex.is_match(s)
+    regex!(r"^E\d{4}$").is_match(s)
 }
 
 fn parse_error_code(stderr_content: &str) -> Vec<StderrResult> {
     // Modified regex pattern with named capture groups
-    let re: OnceCell<Regex> = OnceCell::new();
-    let error_pattern = re.get_or_init(|| {
-        Regex::new(r"error\[(?P<error_code>E\d{4})\]: (?P<error_message_detail>.+?)\n\s+-->.+:(?P<line_number>\d+):").unwrap()
-    });
+    let error_pattern = regex!(
+        r"error\[(?P<error_code>E\d{4})\]: (?P<error_message_detail>.+?)\n\s+-->.+:(?P<line_number>\d+):"
+    );
 
     let mut results = Vec::new();
 
@@ -205,11 +201,8 @@ fn parse_expected(
     //     //~|
     //     //~^
     //     //~^^^^^
-    let re: OnceCell<Regex> = OnceCell::new();
 
-    let captures = re
-        .get_or_init(|| Regex::new(r"//(?:\[(?P<revs>[\w\-,]+)])?~(?P<adjust>\||\^*)").unwrap())
-        .captures(line)?;
+    let captures = regex!(r"//(?:\[(?P<revs>[\w\-,]+)])?~(?P<adjust>\||\^*)").captures(line)?;
 
     let (follow, adjusts) = match &captures["adjust"] {
         "|" => (true, 0),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+//! The main entry point of the program.
+
 use {
     anyhow::{Context, Result},
     clap::Parser,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
-use anyhow::{Context, Result};
-use clap::Parser;
+use {
+    anyhow::{Context, Result},
+    clap::Parser,
+};
 
 mod cli;
 mod errors;

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,9 +1,7 @@
-use std::cell::OnceCell;
-
-use anyhow::Result;
-use regex::Regex;
-
-use crate::errors;
+use {
+    crate::{errors, regex},
+    anyhow::Result,
+};
 
 /// This function takes the rust code as input
 /// and returns the code with DejaGnu directive
@@ -26,12 +24,7 @@ pub fn transform_code(code: &str, stderr_file: Option<&str>) -> Result<String> {
                 new_line = format!("{}", error);
             } else {
                 // For the error on the same line
-                let re: OnceCell<Regex> = OnceCell::new();
-
-                let captures = re
-                    .get_or_init(|| {
-                        Regex::new(r"//(?:\[(?P<revs>[\w\-,]+)])?~(?P<adjust>\||\^*)").unwrap()
-                    })
+                let captures = regex!(r"//(?:\[(?P<revs>[\w\-,]+)])?~(?P<adjust>\||\^*)")
                     .captures(line)
                     .expect("Could not find the error directive");
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,36 +1,47 @@
+//! This module contains the code transformation logic.
+
 use {
     crate::{errors, regex},
     anyhow::Result,
 };
 
-/// This function takes the rust code as input
-/// and returns the code with DejaGnu directive
+/// Transform code to `DejaGnu` format
 pub fn transform_code(code: &str, stderr_file: Option<&str>) -> Result<String> {
+    // Load the rustc error messages, codes, lines and relative line numbers
     let errors = errors::load_error(code, stderr_file);
+    // For storing the transformed code
     let mut new_code = String::new();
 
     let mut line_num = 1;
+    // finding the respective line number and adding the error code
     for line in code.lines() {
         let mut new_line = line.to_string();
         // TODO: This is not the efficient way to find respective line number
         for error in errors.iter() {
+            // Checking the original line number
             if (error.line_num as i32 - error.relative_line_num) != line_num {
                 continue;
             }
             // In rustc test suites, the error directive is
-            // on the same line or the next line not on the previous line
+            // on the same line or on the next line, but not on the previous line
+            // See this: https://rustc-dev-guide.rust-lang.org/tests/ui.html#error-annotations
             // For the error on the next line
             if error.relative_line_num != 0 {
+                // We simply add the error message, not to worry about the code
+                // The error was printed by our overloaded `Display` trait
                 new_line = format!("{}", error);
             } else {
-                // For the error on the same line
+                // For the error on the same line, we need to add error message at the end of the line
                 let captures = regex!(r"//(?:\[(?P<revs>[\w\-,]+)])?~(?P<adjust>\||\^*)")
                     .captures(line)
                     .expect("Could not find the error directive");
 
                 // Get the part of comment before the sigil (e.g. `~^` or ~|)
                 let whole_match = captures.get(0).unwrap();
+                // Get the existing source code before the error directive //~ ERROR or similar to this
                 let before_match = &line[..whole_match.start()];
+
+                // The error was printed by our overloaded `Display` trait
                 new_line = format!("{}{}", before_match, error);
             }
             break;


### PR DESCRIPTION
- Add `regex!` macro for convenient pattern matching
- Fixes: https://github.com/Rust-GCC/rusttest-to-dg/issues/9
- Add detailed doc comments.



---
- Depends on: https://github.com/Rust-GCC/rusttest-to-dg/pull/6