### PR TITLE
Add Exhaustive DejaGnu directives lookup table & update `rustc-1.49.0` paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ Converts `rustc` testcases into dejagnu testcases for `gccrs`
 
 This tool was invoked by the script [run](./run.sh). Furthermore, we need the rustc and gccrs source code to be downloaded on the system. And add their paths to the environment variables `GCCRS_PATH`, `RUST_PATH` and `RUSTTEST_TO_DG_PATH`
 
+You can install gccrs from the [gccrs repository](https://github.com/Rust-GCC/gccrs):
+
+```bash
+git clone https://github.com/Rust-GCC/gccrs.git
+```
+You can install rustc from the [rust repository](https://github.com/rust-lang/rust):
+
+```bash
+git clone https://github.com/rust-lang/rust.git
+
+# Checkout the rustc 1.49.0 version
+cd rust
+git checkout 1.49.0
+```
+
+After that, set the environment variables in your shell configuration file or in the terminal session:
+
 ```bash
 export GCCRS_PATH=/path/to/gccrs
 export RUST_PATH=/path/to/rust

--- a/equivalent-dejagnu-directive.md
+++ b/equivalent-dejagnu-directive.md
@@ -1,0 +1,291 @@
+# DejaGnu equivalvent directives for Rustc test headers:
+
+Rust compiletest tool uses a set of directives in the test headers to control the behavior of the test. See rustc dev guide for more information on the [test directives](https://rustc-dev-guide.rust-lang.org/tests/headers.html#header-commands).
+
+Equivalent DejaGnu directives are used to control the behavior of the test in the `gccrs` test suite
+
+### [Controlling pass/fail expectations](https://rustc-dev-guide.rust-lang.org/tests/ui.html#controlling-passfail-expectations)
+
+- **Pass headers**:
+
+  | Rustc Directive | DejaGnu Directive                                    |
+  | --------------- | ---------------------------------------------------- |
+  | check-pass      |                                                      |
+  | build-pass      |                                                      |
+  | run-pass        | target (compilation,linking and running should pass) |
+
+- **Fail headers**:
+
+  | Rustc Directive | DejaGnu Directive |
+  | --------------- | ----------------- |
+  | check-fail      |                   |
+  | build-fail      |                   |
+  | run-fail        |                   |
+
+The `run-pass` and `run-fail` tests in rust compiletest tool doesn't check the output of program. But dejagnu gives verdict based on the output of the program. So, the `run-pass` and `run-fail` tests in rustc are converted to `target` and `xfail` tests in dejagnu directives.
+
+- **Other headers**:
+
+  | Rustc Directive   | DejaGnu Directive                                         |
+  | ----------------- | --------------------------------------------------------- |
+  | ignore-pass       |                                                           |
+  | check-run-results | xfail (thil will also compare the output of the compiler) |
+
+## [UI](https://rustc-dev-guide.rust-lang.org/tests/ui.html) headers
+
+| Rustc Directive                 | DejaGnu Directive |
+| ------------------------------- | ----------------- |
+| normalize-stderr-32bit          |                   |
+| normalize-stderr-64bit          |                   |
+| normalize-stderr-test           |                   |
+| normalize-stdout-test           |                   |
+| run-rustfix                     |                   |
+| rustfix-only-machine-applicable |                   |
+| stderr-per-bitwidth             |                   |
+| dont-check-compiler-stderr      |                   |
+| dont-check-compiler-stdout      |                   |
+| compare-output-lines-by-subset  |                   |
+
+## [Building auxiliary crates](https://rustc-dev-guide.rust-lang.org/tests/compiletest.html#building-auxiliary-crates)
+
+| Rustc Directive     | DejaGnu Directive |
+| ------------------- | ----------------- |
+| aux-build           |                   |
+| aux-crate           |                   |
+| aux-bin             |                   |
+| aux-codegen-backend |                   |
+
+## [Pretty-printer](https://rustc-dev-guide.rust-lang.org/tests/compiletest.html#pretty-printer-tests) headers
+
+| Rustc Directive     | DejaGnu Directive |
+| ------------------- | ----------------- |
+| pretty-compare-only |                   |
+| pretty-expanded     |                   |
+| pretty-mode         |                   |
+| pp-exact            |                   |
+
+## [Ignoring tests](https://rustc-dev-guide.rust-lang.org/tests/headers.html#ignoring-tests)
+
+| Rustc Directive                    | DejaGnu Directive |
+| ---------------------------------- | ----------------- |
+| ignore-16bit                       |                   |
+| ignore-32bit                       |                   |
+| ignore-64bit                       |                   |
+| ignore-aarch64                     |                   |
+| ignore-aarch64-unknown-linux-gnu   |                   |
+| ignore-android                     |                   |
+| ignore-apple                       |                   |
+| ignore-arm                         |                   |
+| ignore-avr                         |                   |
+| ignore-beta                        |                   |
+| ignore-cdb                         |                   |
+| ignore-compare-mode-next-solver    |                   |
+| ignore-compare-mode-polonius       |                   |
+| ignore-cross-compile               |                   |
+| ignore-debug                       |                   |
+| ignore-eabi                        |                   |
+| ignore-emscripten                  |                   |
+| ignore-endian-big                  |                   |
+| ignore-freebsd                     |                   |
+| ignore-fuchsia                     |                   |
+| ignore-gdb                         |                   |
+| ignore-gdb-version                 |                   |
+| ignore-gnu                         |                   |
+| ignore-haiku                       |                   |
+| ignore-horizon                     |                   |
+| ignore-i686-pc-windows-gnu         |                   |
+| ignore-i686-pc-windows-msvc        |                   |
+| ignore-illumos                     |                   |
+| ignore-ios                         |                   |
+| ignore-linux                       |                   |
+| ignore-lldb                        |                   |
+| ignore-llvm-version                |                   |
+| ignore-loongarch64                 |                   |
+| ignore-macabi                      |                   |
+| ignore-macos                       |                   |
+| ignore-mode-assembly               |                   |
+| ignore-mode-codegen                |                   |
+| ignore-mode-codegen-units          |                   |
+| ignore-mode-coverage-map           |                   |
+| ignore-mode-coverage-run           |                   |
+| ignore-mode-crashes                |                   |
+| ignore-mode-debuginfo              |                   |
+| ignore-mode-incremental            |                   |
+| ignore-mode-js-doc-test            |                   |
+| ignore-mode-mir-opt                |                   |
+| ignore-mode-pretty                 |                   |
+| ignore-mode-run-make               |                   |
+| ignore-mode-run-pass-valgrind      |                   |
+| ignore-mode-rustdoc                |                   |
+| ignore-mode-rustdoc-json           |                   |
+| ignore-mode-ui                     |                   |
+| ignore-mode-ui-fulldeps            |                   |
+| ignore-msp430                      |                   |
+| ignore-msvc                        |                   |
+| ignore-musl                        |                   |
+| ignore-netbsd                      |                   |
+| ignore-nightly                     |                   |
+| ignore-none                        |                   |
+| ignore-nto                         |                   |
+| ignore-nvptx64                     |                   |
+| ignore-nvptx64-nvidia-cuda         |                   |
+| ignore-openbsd                     |                   |
+| ignore-pass                        |                   |
+| ignore-powerpc                     |                   |
+| ignore-remote                      |                   |
+| ignore-riscv64                     |                   |
+| ignore-s390x                       |                   |
+| ignore-sgx                         |                   |
+| ignore-sparc64                     |                   |
+| ignore-spirv                       |                   |
+| ignore-stable                      |                   |
+| ignore-stage1                      |                   |
+| ignore-stage2                      |                   |
+| ignore-test                        |                   |
+| ignore-thumb                       |                   |
+| ignore-thumbv8m.base-none-eabi     |                   |
+| ignore-thumbv8m.main-none-eabi     |                   |
+| ignore-tvos                        |                   |
+| ignore-unix                        |                   |
+| ignore-unknown                     |                   |
+| ignore-uwp                         |                   |
+| ignore-visionos                    |                   |
+| ignore-vxworks                     |                   |
+| ignore-wasi                        |                   |
+| ignore-wasm                        |                   |
+| ignore-wasm32                      |                   |
+| ignore-wasm32-bare                 |                   |
+| ignore-wasm64                      |                   |
+| ignore-watchos                     |                   |
+| ignore-windows                     |                   |
+| ignore-windows-gnu                 |                   |
+| ignore-windows-msvc                |                   |
+| ignore-x32                         |                   |
+| ignore-x86                         |                   |
+| ignore-x86_64                      |                   |
+| ignore-x86_64-apple-darwin         |                   |
+| ignore-x86_64-pc-windows-gnu       |                   |
+| ignore-x86_64-unknown-linux-gnu    |                   |
+| only-16bit                         |                   |
+| only-32bit                         |                   |
+| only-64bit                         |                   |
+| only-aarch64                       |                   |
+| only-aarch64-unknown-linux-gnu     |                   |
+| only-apple                         |                   |
+| only-arm                           |                   |
+| only-avr                           |                   |
+| only-beta                          |                   |
+| only-bpf                           |                   |
+| only-cdb                           |                   |
+| only-gnu                           |                   |
+| only-i686-pc-windows-gnu           |                   |
+| only-i686-pc-windows-msvc          |                   |
+| only-ios                           |                   |
+| only-linux                         |                   |
+| only-loongarch64                   |                   |
+| only-loongarch64-unknown-linux-gnu |                   |
+| only-macos                         |                   |
+| only-mips                          |                   |
+| only-mips64                        |                   |
+| only-msp430                        |                   |
+| only-msvc                          |                   |
+| only-nightly                       |                   |
+| only-nvptx64                       |                   |
+| only-powerpc                       |                   |
+| only-riscv64                       |                   |
+| only-s390x                         |                   |
+| only-sparc                         |                   |
+| only-sparc64                       |                   |
+| only-stable                        |                   |
+| only-thumb                         |                   |
+| only-tvos                          |                   |
+| only-unix                          |                   |
+| only-visionos                      |                   |
+| only-wasm32                        |                   |
+| only-wasm32-bare                   |                   |
+| only-wasm32-wasip1                 |                   |
+| only-watchos                       |                   |
+| only-windows                       |                   |
+| only-windows-gnu                   |                   |
+| only-windows-msvc                  |                   |
+| only-x86                           |                   |
+| only-x86_64                        |                   |
+| only-x86_64-fortanix-unknown-sgx   |                   |
+| only-x86_64-pc-windows-gnu         |                   |
+| only-x86_64-pc-windows-msvc        |                   |
+| only-x86_64-unknown-linux-gnu      |                   |
+| needs-asm-support                  |                   |
+| needs-deterministic-layouts        |                   |
+| needs-dlltool                      |                   |
+| needs-dynamic-linking              |                   |
+| needs-force-clang-based-tests      |                   |
+| needs-git-hash                     |                   |
+| needs-llvm-components              |                   |
+| needs-llvm-zstd                    |                   |
+| needs-profiler-support             |                   |
+| needs-relocation-model-pic         |                   |
+| needs-run-enabled                  |                   |
+| needs-rust-lld                     |                   |
+| needs-sanitizer-address            |                   |
+| needs-sanitizer-cfi                |                   |
+| needs-sanitizer-dataflow           |                   |
+| needs-sanitizer-hwaddress          |                   |
+| needs-sanitizer-kcfi               |                   |
+| needs-sanitizer-leak               |                   |
+| needs-sanitizer-memory             |                   |
+| needs-sanitizer-memtag             |                   |
+| needs-sanitizer-safestack          |                   |
+| needs-sanitizer-shadow-call-stack  |                   |
+| needs-sanitizer-support            |                   |
+| needs-sanitizer-thread             |                   |
+| needs-symlink                      |                   |
+| needs-threads                      |                   |
+| needs-unwind                       |                   |
+| needs-wasmtime                     |                   |
+| needs-xray                         |                   |
+| no-system-llvm                     |                   |
+| min-llvm-version                   |                   |
+| min-system-llvm-version            |                   |
+
+## [Environment variable headers](https://rustc-dev-guide.rust-lang.org/tests/headers.html#environment-variable-headers)
+
+| Rustc Directive | DejaGnu Directive |
+| --------------- | ----------------- |
+| rustc-env       |                   |
+| exec-env        |                   |
+| unset-exec-env  |                   |
+| unset-rustc-env |                   |
+
+## [Miscellaneous headers](https://rustc-dev-guide.rust-lang.org/tests/headers.html#miscellaneous-headers)
+
+| Rustc Directive       | DejaGnu Directive                            |
+| --------------------- | -------------------------------------------- |
+| compile-flags         |                                              |
+| run-flags             |                                              |
+| edition               | "dg-additional-options "-frust-edition=2018" |
+| failure-status        |                                              |
+| should-fail           |                                              |
+| gate-test-X           |                                              |
+| error-pattern         |                                              |
+| incremental           |                                              |
+| no-prefer-dynamic     |                                              |
+| no-auto-check-cfg     |                                              |
+| force-host            |                                              |
+| revisions             |                                              |
+| unused-revision-names |                                              |
+| forbid-output         |                                              |
+| should-ice            |                                              |
+| known-bug             |                                              |
+
+## [Assembly](https://rustc-dev-guide.rust-lang.org/tests/compiletest.html#assembly-tests) headers
+
+| Rustc Directive | DejaGnu Directive |
+| --------------- | ----------------- |
+| assembly-output |                   |
+
+## [Tool-specific headers](https://rustc-dev-guide.rust-lang.org/tests/headers.html#tool-specific-headers)
+
+| Rustc Directive | DejaGnu Directive |
+| --------------- | ----------------- |
+| filecheck-flags |                   |
+| llvm-cov-flags  |                   |

--- a/run.sh
+++ b/run.sh
@@ -43,9 +43,9 @@ fi
 
 
 # Copying the RUST_PATH/tests/ui to GCCRS_PATH/gcc/testsuite/rust/rustc
-echo -e "Copying tests from $RUST_PATH/tests/ui to $GCCRS_PATH/gcc/testsuite/rust/rustc"
-cp -r "$RUST_PATH"/tests/ui "$GCCRS_PATH"/gcc/testsuite/rust/rustc
-echo -e "Copied $RUST_PATH/tests/ui tests to $GCCRS_PATH/gcc/testsuite/rust/rustc/ui"
+echo -e "Copying tests from $RUST_PATH/src/test/ui to $GCCRS_PATH/gcc/testsuite/rust/rustc"
+cp -r "$RUST_PATH"/src/test/ui "$GCCRS_PATH"/gcc/testsuite/rust/rustc
+echo -e "Copied $RUST_PATH/src/test/ui tests to $GCCRS_PATH/gcc/testsuite/rust/rustc/ui"
 cd "$GCCRS_PATH"/gcc/testsuite/rust/rustc/ui
 
 process_files() {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -108,7 +108,7 @@ impl fmt::Display for Error {
         let error_code = if error_code.is_empty() {
             error_code.to_owned()
         } else {
-            format!(".{}.", error_code)
+            format!(".{error_code}.")
         };
 
         let rel_line_number = if self.relative_line_num == 0 {

--- a/src/header.rs
+++ b/src/header.rs
@@ -11,7 +11,7 @@ pub struct HeaderLine<'ln> {
     pub dejagnu_header: String,
 }
 
-pub fn parse_additional_options(code: &str) -> Vec<HeaderLine> {
+pub fn parse_additional_options(code: &str) -> Vec<HeaderLine<'_>> {
     let mut headers = Vec::new();
 
     for (line_number, line) in code.lines().enumerate() {
@@ -32,7 +32,7 @@ pub fn is_header_line(line: &str) -> bool {
     line.trim_start().starts_with("//@")
 }
 
-fn add_additional_options(code: &str, line_number: usize) -> Option<HeaderLine> {
+fn add_additional_options(code: &str, line_number: usize) -> Option<HeaderLine<'_>> {
     //TODO: If we know the file extension, then update this to
     // let comment = if testfile.extension().is_some_and(|e| e == "rs") { "//@" } else { "#" };
     let comment = "//@";

--- a/src/header.rs
+++ b/src/header.rs
@@ -84,8 +84,5 @@ fn parse_name_value_directive(line: &str, directive: &str) -> Option<String> {
 }
 
 fn to_dejagnu_edition(edition: &str) -> String {
-    format!(
-        "// {{ dg-additional-options \"-frust-edition={}\" }}",
-        edition
-    )
+    format!("// {{ dg-additional-options \"-frust-edition={edition}\" }}")
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -49,7 +49,7 @@ pub fn transform_code(code: &str, stderr_file: Option<&str>) -> Result<String> {
                 if error.relative_line_num != 0 {
                     // We simply add the error message, not to worry about the code
                     // The error was printed by our overloaded `Display` trait
-                    new_line = format!("{}", error);
+                    new_line = format!("{error}");
                 } else {
                     // For the error on the same line, we need to add error message at the end of the line
                     let captures = captures_regex
@@ -62,7 +62,7 @@ pub fn transform_code(code: &str, stderr_file: Option<&str>) -> Result<String> {
                     let before_match = &line[..whole_match.start()];
 
                     // The error was printed by our overloaded `Display` trait
-                    new_line = format!("{}{}", before_match, error);
+                    new_line = format!("{before_match}{error}");
                 }
                 break;
             }


### PR DESCRIPTION
* Added `equivalent-dejagnu-directive.md`, a mapping of Rustc compiletest test header directives to their DejaGnu equivalents

> [!NOTE] 
> It is not possible that there exists all equivalent 1-1 rustc to dejagnu directives, we are just added here for completeness



* Updated string formatting to use Rust's inline `{var}` syntax for improved consistency in `src/errors.rs`, `src/header.rs`, and `src/transform.rs`.
* Fixed lifetime annotations in function signatures in `src/header.rs` to ensure correct lifetimes for returned values.


* Updated the test copying path in `run.sh` to use [rustc 1.49.0 ui tests](https://github.com/rust-lang/rust/tree/1.49.0/src/test/ui) `src/test/ui` instead of latest rustc directory format `tests/ui`

* Update `README.md` to include `rustc-1.49.0` and `gccrs` repo